### PR TITLE
Cleanup build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-include/
-lib
+*.h
+*.a
+*.pc
+.install-bls

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,5 @@ $(DEPS): .install-bls  ;
 
 
 clean:
-	rm -rf $(DEPS)
+	rm -rf $(DEPS) .install-bls
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-all: include/libbls_signatures.h
+DEPS:=libbls_signatures.h libbls_signatures.pc libbls_signatures.a
+
+all: $(DEPS)
 .PHONY: all
 
 
-include/libbls_signatures.h:
+$(DEPS): .install-bls  ;
+
+.install-bls: bls-signatures
 	./install-bls-signatures
+	@touch $@
 
 
 clean:
-	rm -rf include
-	rm -rf lib
+	rm -rf $(DEPS)
 .PHONY: clean

--- a/bls.go
+++ b/bls.go
@@ -4,9 +4,9 @@ import (
 	"unsafe"
 )
 
-// #cgo LDFLAGS: -L${SRCDIR}/lib -lbls_signatures
-// #cgo pkg-config: ${SRCDIR}/lib/pkgconfig/libbls_signatures.pc
-// #include "./include/libbls_signatures.h"
+// #cgo LDFLAGS: ${SRCDIR}/libbls_signatures.a
+// #cgo pkg-config: ${SRCDIR}/libbls_signatures.pc
+// #include "./libbls_signatures.h"
 import "C"
 
 // Hash computes the digest of a message

--- a/bls_test.go
+++ b/bls_test.go
@@ -3,13 +3,10 @@ package bls
 import (
 	"testing"
 
-	tf "github.com/filecoin-project/go-filecoin/testhelpers/testflags"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBLSSigningAndVerification(t *testing.T) {
-	tf.UnitTest(t)
-
 	// generate private keys
 	fooPrivateKey := PrivateKeyGenerate()
 	barPrivateKey := PrivateKeyGenerate()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/filecoin-project/go-bls-sigs
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/install-bls-signatures
+++ b/install-bls-signatures
@@ -20,7 +20,7 @@ else
     (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir}, falling back to local build")
     build_from_source "${subm_dir}"
 
-    find "${subm_dir}" -type f -name libbls_signatures.h -exec mv -- "{}" . \;
+    find "${subm_dir}" -type f -name libbls_signatures.h -exec cp -- "{}" . \;
     find "${subm_dir}" -type f -name libbls_signatures_ffi.a -exec cp -- "{}" libbls_signatures.a \;
     find "${subm_dir}" -type f -name libbls_signatures.pc -exec cp -- "{}" . \;
 fi

--- a/install-bls-signatures
+++ b/install-bls-signatures
@@ -21,6 +21,6 @@ else
     build_from_source "${subm_dir}"
 
     find "${subm_dir}" -type f -name libbls_signatures.h -exec mv -- "{}" . \;
-    find "${subm_dir}" -type f -name libbls_signatures.a -exec cp -- "{}" . \;
+    find "${subm_dir}" -type f -name libbls_signatures_ffi.a -exec cp -- "{}" libbls_signatures.a \;
     find "${subm_dir}" -type f -name libbls_signatures.pc -exec cp -- "{}" . \;
 fi

--- a/install-bls-signatures
+++ b/install-bls-signatures
@@ -13,16 +13,14 @@ if download_release_tarball tarball_path "${subm_dir}"; then
     tmp_dir=$(mktemp -d)
     tar -C "$tmp_dir" -xzf "$tarball_path"
 
-    cp -R "${tmp_dir}/include" .
-    cp -R "${tmp_dir}/lib" .
+    cp "${tmp_dir}/include/libbls_signatures.h" .
+    cp "${tmp_dir}/lib/libbls_signatures.a" .
+    cp "${tmp_dir}/lib/pkgconfig/libbls_signatures.pc" .
 else
     (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir}, falling back to local build")
     build_from_source "${subm_dir}"
 
-    mkdir -p include
-    mkdir -p lib/pkgconfig
-
-    find "${subm_dir}" -type f -name libbls_signatures.h -exec mv -- "{}" ./lib/bls-signatures/include/ \;
-    find "${subm_dir}" -type f -name libbls_signatures_ffi.a -exec cp -- "{}" ./lib/bls-signatures/lib/ \;
-    find "${subm_dir}" -type f -name libbls_signatures.pc -exec cp -- "{}" ./lib/bls-signatures/lib/pkgconfig/ \;
+    find "${subm_dir}" -type f -name libbls_signatures.h -exec mv -- "{}" . \;
+    find "${subm_dir}" -type f -name libbls_signatures.a -exec cp -- "{}" . \;
+    find "${subm_dir}" -type f -name libbls_signatures.pc -exec cp -- "{}" . \;
 fi


### PR DESCRIPTION
As recommended in `go help cgo`, move all C dependencies of the pacakge to
the package directory itself.