### PR TITLE
feat(consume latest bls-signatures SHA)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+jobs:
+  build_linux:
+    docker:
+      - image: circleci/golang:1.12.1-stretch
+    working_directory: /go/src/github.com/filecoin-project/go-bls-sigs
+    resource_class: xlarge
+    steps:
+      - run:
+          name: Configure environment variables
+          command: |
+            echo 'export FILECOIN_PARAMETER_CACHE="${HOME}/filecoin-proof-parameters/"' >> $BASH_ENV
+            echo 'export FILECOIN_USE_PRECOMPILED_RUST_PROOFS=yes' >> $BASH_ENV
+            echo 'export GO111MODULE=on' >> $BASH_ENV
+      - checkout
+      - run:
+          name: Update submodules
+          command: git submodule update --init --recursive
+      - run:
+          name: Build upstream project
+          command: make
+      - run:
+          name: Build project
+          command: go build .
+
+workflows:
+  version: 2
+  test_all:
+    jobs:
+      - build_linux


### PR DESCRIPTION
## Why does this PR exist?

[This PR](https://github.com/filecoin-project/go-sectorbuilder/pull/10) includes the latest version of rust-fil-proofs and rust-fil-sector-builder. This new version uses toolchain `nightly-2019-08-09`, which needs to be kept in sync with whatever the bls-signatures project uses. I've already updated bls-signatures; this PR points the CGO bindings-repo at the correct submodule SHA.

## Changes in this PR

- add basic CircleCI configuration
- bump submodule SHA

## Next Steps

Once merged, go-filecoin and go-lotus submodules should be updated to point at the new HEAD of master.

--------

## bls-signatures commits

```
-----------------------------------------------
commit f8bbef3c532e733680e215a288c933fb64bbea53
Merge: c2f2881 00e9997
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Tue Aug 13 15:41:04 2019 -0700

    Merge pull request #13 from filecoin-project/feat/new-rust-toolchain
    
    update rust-toolchain to match version used by rust-fil-sector-builder


-----------------------------------------------
commit 00e9997bd2a0fd724e437391054fcccd08c20a28
Author: laser <l@s3r.me>
Date:   Tue Aug 13 14:53:28 2019 -0700

    feat(update rust-toolchain to match version used by rust-fil-sector-builder)


```