### PR TITLE
feat: update bls-signatures to latest version

### DIFF
--- a/bls_test.go
+++ b/bls_test.go
@@ -51,8 +51,8 @@ func BenchmarkBLSVerify(b *testing.B) {
 	digest := Hash(msg)
 
 	sig := PrivateKeySign(priv, msg)
-	fmt.Println("SIG SIZE: ", len(sig))
-	fmt.Println("SIG: ", sig)
+	// fmt.Println("SIG SIZE: ", len(sig))
+	// fmt.Println("SIG: ", sig)
 	pubk := PrivateKeyPublicKey(priv)
 
 	b.ResetTimer()
@@ -84,7 +84,7 @@ func benchmarkBLSVerifyBatchSize(size int) func(b *testing.B) {
 			digests = append(digests, Hash(msg))
 			priv := PrivateKeyGenerate()
 			sig := PrivateKeySign(priv, msg)
-			sigs = append(sigs, sig)
+			sigs = append(sigs, *sig)
 			pubk := PrivateKeyPublicKey(priv)
 			pubks = append(pubks, pubk)
 		}


### PR DESCRIPTION
## Before

```
BenchmarkBLSVerify-16         	     296	   4154676 ns/op
Aggregate took:  8.157109ms
BenchmarkBLSVerifyBatch/10-16 	Aggregate took:  8.338691ms
      73	  15967179 ns/op
Aggregate took:  44.854322ms
BenchmarkBLSVerifyBatch/50-16 	Aggregate took:  41.099415ms
      15	  69763153 ns/op
Aggregate took:  81.724886ms
BenchmarkBLSVerifyBatch/100-16         	Aggregate took:  83.48589ms
       8	 144553960 ns/op
Aggregate took:  236.839288ms
BenchmarkBLSVerifyBatch/300-16         	Aggregate took:  283.373793ms
Aggregate took:  259.616619ms
       3	 414438390 ns/op
Aggregate took:  915.355037ms
BenchmarkBLSVerifyBatch/1000-16        	       1	1356042867 ns/op
Aggregate took:  3.568430098s
BenchmarkBLSVerifyBatch/4000-16        	       1	5276913589 ns/op
```

## After

```
BenchmarkBLSVerify-16         	     284	   4174348 ns/op
Aggregate took:  1.814091ms
BenchmarkBLSVerifyBatch/10-16 	Aggregate took:  1.768416ms
Aggregate took:  1.691277ms
     153	   7835080 ns/op
Aggregate took:  6.264766ms
BenchmarkBLSVerifyBatch/50-16 	Aggregate took:  6.281761ms
      48	  23923083 ns/op
Aggregate took:  11.562898ms
BenchmarkBLSVerifyBatch/100-16         	Aggregate took:  11.290891ms
      24	  46492734 ns/op
Aggregate took:  33.042956ms
BenchmarkBLSVerifyBatch/300-16         	Aggregate took:  32.9692ms
       8	 130491852 ns/op
Aggregate took:  105.918367ms
BenchmarkBLSVerifyBatch/1000-16        	Aggregate took:  107.546119ms
Aggregate took:  104.49398ms
       3	 400473662 ns/op
Aggregate took:  416.857908ms
BenchmarkBLSVerifyBatch/4000-16        	       1	1624972825 ns/op
```