### PR TITLE
deprecate project in favor of filecoin-ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# Go Binding for BLS Signatures
+# DEPRECATED
+
+This repo is no longer supported. Please consider using
+[filecoin-ffi](https://github.com/filecoin-project/filecoin-ffi) instead.


### PR DESCRIPTION
## Why does this PR exist?

We've combined proofs and bls FFI code (both CGO and C-like Rusty bindings) into a [new repo](https://github.com/filecoin-project/filecoin-ffi), which means that we can stop depending on this repo.